### PR TITLE
Make final jar smaller by 1MB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <minimizeJar>true</minimizeJar>
                             <artifactSet>
                                 <excludes>
                                     <exclude>org.projectrainbow:minecraft-server</exclude>

--- a/src/main/java/org/projectrainbow/RainbowLauncher.java
+++ b/src/main/java/org/projectrainbow/RainbowLauncher.java
@@ -17,7 +17,7 @@ public class RainbowLauncher {
 
     public static void main(String[] args) throws Exception {
         File rainbowJar = new File("Rainbow.jar");
-        downloadFile("http://ci.codecrafter47.de/job/Rainbow/lastSuccessfulBuild/artifact/rainbow/target/Rainbow.jar", rainbowJar);
+        downloadFile("https://ci.codecrafter47.de/job/Rainbow/lastSuccessfulBuild/artifact/rainbow/target/Rainbow.jar", rainbowJar);
         addURL(rainbowJar.toURI().toURL());
 
         File propertiesFile = new File("RainbowLauncher.properties");

--- a/src/main/java/org/projectrainbow/RainbowLauncher.java
+++ b/src/main/java/org/projectrainbow/RainbowLauncher.java
@@ -17,7 +17,7 @@ public class RainbowLauncher {
 
     public static void main(String[] args) throws Exception {
         File rainbowJar = new File("Rainbow.jar");
-        downloadFile("https://ci.codecrafter47.de/job/Rainbow/lastSuccessfulBuild/artifact/rainbow/target/Rainbow.jar", rainbowJar);
+        downloadFile("http://ci.codecrafter47.de/job/Rainbow/lastSuccessfulBuild/artifact/rainbow/target/Rainbow.jar", rainbowJar);
         addURL(rainbowJar.toURI().toURL());
 
         File propertiesFile = new File("RainbowLauncher.properties");


### PR DESCRIPTION
The RainbowLauncher.jar on https://ci.codecrafter47.de/job/RainbowLauncher/ is 

**2.50MB** pull this to make it less then **1MB**

I've set the maven-shade-plugin to remove classes from the libs that are not used in RainbowLauncher.